### PR TITLE
Explicitly say "maximal" goal value is 100 in winnability definitions.

### DIFF
--- a/gdl.html
+++ b/gdl.html
@@ -531,9 +531,9 @@ exactly one goal value in every state reachable from the initial state, and goal
 
 <p><b>Definition 24</b> (Winnability). <i>A game description in GDL is </i>strongly winnable<i> if and only if, for some
 role, there is a sequence of individual moves of that role that leads to a terminal state of the game where that
-role's goal value is maximal. A game description in GDL is </i>weakly winnable<i> if and only if, for every role,
+role's goal value is 100. A game description in GDL is </i>weakly winnable<i> if and only if, for every role,
 there is a sequence of joint moves of all roles that leads to a terminal state where that role's goal value is
-maximal.</i></p>
+100.</i></p>
 
 <p><b>Definition 25</b> (Well-formed Games). <i>A game description in GDL is </i>well-formed<i> if it terminates, is monotonic,
 and is both playable and weakly winnable.</i></p>


### PR DESCRIPTION
I've seen some people claim that the "maximal" goal value (as referred to in the strongly winnable/weakly winnable definitions) refers only to the maximal score listed in the game description, or even the maximal score that the player can achieve in the game tree, which is a tad self-referential and tautological. Proposing a wording change to remove this ambiguity.
